### PR TITLE
Update Rosegarden to 24.06 (plus a couple of other fixes)

### DIFF
--- a/com.rosegardenmusic.rosegarden.json
+++ b/com.rosegardenmusic.rosegarden.json
@@ -62,9 +62,9 @@
       "sources": [
         {
           "type": "archive",
-          "x-checked-data": {
           "url": "https://downloads.sourceforge.net/project/rosegarden/rosegarden/24.06/rosegarden-24.06.tar.xz",
           "sha256": "866cd4297c128a68208edd28a37808f278f630219533fff32441ad6647e09c27",
+          "x-checker-data": {
               "type": "anitya",
               "project-id": 8939,
               "url-template": "https://downloads.sourceforge.net/project/rosegarden/rosegarden/$version/rosegarden-$version.tar.xz"

--- a/com.rosegardenmusic.rosegarden.json
+++ b/com.rosegardenmusic.rosegarden.json
@@ -75,7 +75,7 @@
           "paths": [
               "rosegarden-mime-icon.patch",
               "rosegarden-desktop-file-keywords.patch",
-              "rosegarden-appdata-id-and-desktop-launchable.patch"
+              "rosegarden-appdata-desktop-launchable.patch"
           ]
         }
       ]

--- a/com.rosegardenmusic.rosegarden.json
+++ b/com.rosegardenmusic.rosegarden.json
@@ -77,6 +77,10 @@
         {
           "type": "patch",
           "path": "rosegarden-desktop-file-keywords.patch"
+        },
+        {
+          "type": "patch",
+          "path": "rosegarden-appdata-id-and-desktop-launchable.patch"
         }
       ]
     }

--- a/com.rosegardenmusic.rosegarden.json
+++ b/com.rosegardenmusic.rosegarden.json
@@ -73,6 +73,10 @@
         {
           "type": "patch",
           "path": "rosegarden-mime-icon.patch"
+        },
+        {
+          "type": "patch",
+          "path": "rosegarden-desktop-file-keywords.patch"
         }
       ]
     }

--- a/com.rosegardenmusic.rosegarden.json
+++ b/com.rosegardenmusic.rosegarden.json
@@ -72,15 +72,11 @@
         },
         {
           "type": "patch",
-          "path": "rosegarden-mime-icon.patch"
-        },
-        {
-          "type": "patch",
-          "path": "rosegarden-desktop-file-keywords.patch"
-        },
-        {
-          "type": "patch",
-          "path": "rosegarden-appdata-id-and-desktop-launchable.patch"
+          "paths": [
+              "rosegarden-mime-icon.patch",
+              "rosegarden-desktop-file-keywords.patch",
+              "rosegarden-appdata-id-and-desktop-launchable.patch"
+          ]
         }
       ]
     }

--- a/com.rosegardenmusic.rosegarden.json
+++ b/com.rosegardenmusic.rosegarden.json
@@ -62,9 +62,9 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://downloads.sourceforge.net/project/rosegarden/rosegarden/23.12/rosegarden-23.12.tar.xz",
-          "sha256": "3f57e66460044efea082379c9706612fe135b6e81f16cbf0bebe859174fe9332",
           "x-checked-data": {
+          "url": "https://downloads.sourceforge.net/project/rosegarden/rosegarden/24.06/rosegarden-24.06.tar.xz",
+          "sha256": "866cd4297c128a68208edd28a37808f278f630219533fff32441ad6647e09c27",
               "type": "anitya",
               "project-id": 8939,
               "url-template": "https://downloads.sourceforge.net/project/rosegarden/rosegarden/$version/rosegarden-$version.tar.xz"

--- a/rosegarden-appdata-desktop-launchable.patch
+++ b/rosegarden-appdata-desktop-launchable.patch
@@ -1,5 +1,5 @@
---- rosegarden.appdata-old.xml	2024-06-07 18:27:30.117123029 +0100
-+++ rosegarden.appdata.xml	2024-06-07 20:28:05.342376524 +0100
+--- rosegarden-1/data/appdata/rosegarden.appdata.xml	2024-06-07 18:27:30.117123029 +0100
++++ rosegarden-1/data/appdata/rosegarden.appdata.xml	2024-06-07 20:28:05.342376524 +0100
 @@ -2,6 +2,7 @@
  <!-- Copyright 2018-2024 Rosegarden development team -->
  <component type="desktop">

--- a/rosegarden-appdata-desktop-launchable.patch
+++ b/rosegarden-appdata-desktop-launchable.patch
@@ -1,11 +1,9 @@
---- rosegarden-1/data/appdata/rosegarden.appdata.xml	2024-06-07 18:27:30.117123029 +0100
-+++ rosegarden-1/data/appdata/rosegarden.appdata.xml	2024-06-07 18:29:04.831009405 +0100
-@@ -1,7 +1,8 @@
- <?xml version="1.0" encoding="utf-8"?>
+--- rosegarden.appdata-old.xml	2024-06-07 18:27:30.117123029 +0100
++++ rosegarden.appdata.xml	2024-06-07 20:28:05.342376524 +0100
+@@ -2,6 +2,7 @@
  <!-- Copyright 2018-2024 Rosegarden development team -->
  <component type="desktop">
--    <id>com.rosegardenmusic.rosegarden.desktop</id>
-+    <id>com.rosegardenmusic.rosegarden</id>
+     <id>com.rosegardenmusic.rosegarden.desktop</id>
 +    <launchable type="desktop-id">com.rosegardenmusic.rosegarden.desktop</launchable>
      <name>Rosegarden</name>
      <name xml:lang="fr">Rosegarden</name>

--- a/rosegarden-appdata-id-and-desktop-launchable.patch
+++ b/rosegarden-appdata-id-and-desktop-launchable.patch
@@ -1,0 +1,12 @@
+--- rosegarden-1/data/appdata/rosegarden.appdata.xml	2024-06-07 18:27:30.117123029 +0100
++++ rosegarden-1/data/appdata/rosegarden.appdata.xml	2024-06-07 18:29:04.831009405 +0100
+@@ -1,7 +1,8 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <!-- Copyright 2018-2024 Rosegarden development team -->
+ <component type="desktop">
+-    <id>com.rosegardenmusic.rosegarden.desktop</id>
++    <id>com.rosegardenmusic.rosegarden</id>
++    <launchable type="desktop-id">com.rosegardenmusic.rosegarden.desktop</launchable>
+     <name>Rosegarden</name>
+     <name xml:lang="fr">Rosegarden</name>
+     <summary xml:lang="fr">Séquenceur MIDI/audio et éditeur de partitions</summary>

--- a/rosegarden-desktop-file-keywords.patch
+++ b/rosegarden-desktop-file-keywords.patch
@@ -1,0 +1,11 @@
+--- rosegarden-1/data/desktop/com.rosegardenmusic.rosegarden.desktop	2024-06-07 18:10:23.940496943 +0100
++++ rosegarden-1/data/desktop/com.rosegardenmusic.rosegarden.desktop	2024-06-07 18:10:48.020988772 +0100
+@@ -4,7 +4,7 @@
+ Exec=rosegarden %f
+ StartupWMClass=Rosegarden
+ MimeType=audio/x-rosegarden-composition;audio/x-rosegarden-device;audio/x-rosegarden-project;audio/x-rosegarden-template;audio/midi;
+-Keywords=midi audio sequencer music notation score
++Keywords=midi;audio;sequencer;music;notation;score;
+ X-KDE-NativeMimeType=audio/x-rosegarden-composition
+ Icon=rosegarden
+ Comment=MIDI and Audio Sequencer and Notation Editor


### PR DESCRIPTION
The "couple of other fixes" in question:
- Fixing a typo in Flatpak manifest that prevented the Flatpak External Data Checker from scanning this repo.
- Adding a patch to the manifest for the desktop file to make sure the keywords there are properly separated with semicolons (instead of just spaces).